### PR TITLE
create the config file with the correct filename

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -64,7 +64,7 @@ func NewYAMLFile() *YAMLFile {
 	if err != nil {
 		log.Fatal(err)
 	}
-	return &YAMLFile{path: fmt.Sprintf("%s/.ecs-commander.yaml", usr.HomeDir)}
+	return &YAMLFile{path: fmt.Sprintf("%s/.ecsy.yaml", usr.HomeDir)}
 }
 
 // ReadYAMLFile Sets the file to be used for storing config


### PR DESCRIPTION
When the config file doesn't exist, ecsy will create the config file with the wrong file name. This required the user to `touch ecsy.yaml` first so that it can then write and read from the correct space.

This fix changes the config file to be created with the correct filename.