### PR TITLE
Treat quoted strings together

### DIFF
--- a/ecs/command_utils.go
+++ b/ecs/command_utils.go
@@ -1,0 +1,16 @@
+package ecs
+
+import (
+	"encoding/csv"
+	"strings"
+)
+
+func parseCommandOverride(command string) ([]string, error) {
+	reader := csv.NewReader(strings.NewReader(command))
+	reader.Comma = ' '
+	commands, err := reader.Read()
+	if err != nil {
+		return nil, err
+	}
+	return commands, nil
+}

--- a/ecs/wrapper.go
+++ b/ecs/wrapper.go
@@ -716,12 +716,12 @@ func CreateScheduledTask(cluster, service, taskSuffix, scheduleExpression, comma
 		target.RoleArn = role.Arn
 	}
 	if command != "" {
-	    reader := csv.NewReader(strings.NewReader(command))
-        reader.Comma = ' '
-        commands, err := reader.Read()
-        if err != nil {
-            return err
-        }
+		reader := csv.NewReader(strings.NewReader(command))
+		reader.Comma = ' '
+		commands, err := reader.Read()
+		if err != nil {
+			return err
+		}
 
 		overrides := ecsCommandOverrideJSON{
 			ContainerOverrides: []containerOverride{

--- a/ecs/wrapper.go
+++ b/ecs/wrapper.go
@@ -3,6 +3,7 @@ package ecs
 import (
 	"bufio"
 	"encoding/json"
+	"encoding/csv"
 	"fmt"
 	"os"
 	"path"
@@ -715,11 +716,18 @@ func CreateScheduledTask(cluster, service, taskSuffix, scheduleExpression, comma
 		target.RoleArn = role.Arn
 	}
 	if command != "" {
+	    reader := csv.NewReader(strings.NewReader(command))
+        reader.Comma = ' '
+        commands, err := reader.Read()
+        if err != nil {
+            return err
+        }
+
 		overrides := ecsCommandOverrideJSON{
 			ContainerOverrides: []containerOverride{
 				containerOverride{
 					ContainerName: *taskDefinition.ContainerDefinitions[0].Name,
-					Command:       strings.Split(command, " "),
+					Command:       commands,
 				},
 			},
 		}

--- a/ecs/wrapper.go
+++ b/ecs/wrapper.go
@@ -2,7 +2,6 @@ package ecs
 
 import (
 	"bufio"
-	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -716,13 +715,10 @@ func CreateScheduledTask(cluster, service, taskSuffix, scheduleExpression, comma
 		target.RoleArn = role.Arn
 	}
 	if command != "" {
-		reader := csv.NewReader(strings.NewReader(command))
-		reader.Comma = ' '
-		commands, err := reader.Read()
+		commands, err := parseCommandOverride(command)
 		if err != nil {
-			return err
+			return fmt.Errorf("error in command format: %v", err)
 		}
-
 		overrides := ecsCommandOverrideJSON{
 			ContainerOverrides: []containerOverride{
 				containerOverride{

--- a/ecs/wrapper.go
+++ b/ecs/wrapper.go
@@ -2,8 +2,8 @@ package ecs
 
 import (
 	"bufio"
-	"encoding/json"
 	"encoding/csv"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path"

--- a/ecs/wrapper.go
+++ b/ecs/wrapper.go
@@ -720,7 +720,7 @@ func CreateScheduledTask(cluster, service, taskSuffix, scheduleExpression, comma
 		reader.Comma = ' '
 		commands, err := reader.Read()
 		if err != nil {
-			return err
+			return fmt.Errorf("command syntax invalid: %v", err)
 		}
 
 		overrides := ecsCommandOverrideJSON{

--- a/ecs/wrapper_test.go
+++ b/ecs/wrapper_test.go
@@ -1,0 +1,30 @@
+package ecs
+
+import "testing"
+
+var commandOverrideTests = []struct {
+	commandString    string
+	expectedOverride []string
+}{
+	{"node src/bin/cli.js generate-snapshots", []string{"node", "src/bin/cli.js", "generate-snapshots"}},
+	{
+		"sh -c \"/var/www/qc2-crons; php /var/www/app/Console/cake.php cron generateScorecardsData\"",
+		[]string{"sh", "-c", "/var/www/qc2-crons; php /var/www/app/Console/cake.php cron generateScorecardsData"},
+	},
+}
+
+func TestCommandParsing(t *testing.T) {
+	for _, args := range commandOverrideTests {
+		t.Run(args.commandString, func(t *testing.T) {
+			override, err := parseCommandOverride(args.commandString)
+			if err != nil && args.expectedOverride != nil {
+				t.Errorf("expected error")
+			}
+			for i := range override {
+				if override[i] != args.expectedOverride[i] {
+					t.Errorf("expected override %v , got %v", args.expectedOverride, override)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
If there are quotes in commands, treat them together and do not split based on space